### PR TITLE
add: support for package.artifact

### DIFF
--- a/package-size.js
+++ b/package-size.js
@@ -41,8 +41,16 @@ module.exports = class PackageLimit {
             }
             
             const individually = !!functionPackage.individually || !!servicePackage.individually;
-            const fileName = individually ? functionName : serviceName;
-            const filePath = path.join(servicePath, '.serverless', `${fileName}.zip`);
+            const { artifact } = individually ? functionPackage : servicePackage;
+            
+            let filePath;
+            
+            if (artifact) {
+                filePath = path.join(servicePath, artifact);
+            } else {
+                const fileName = individually ? functionName : serviceName;
+                filePath = path.join(servicePath, '.serverless', `${fileName}.zip`);
+            }
 
             if (checked.has(filePath)) {
                 return Promise.resolve();


### PR DESCRIPTION
If `package.artifact` is specified in `serverless.yml`, this plugin fails with the following error:

```
  Error: ENOENT: no such file or directory, stat '/home/myself/my-project/.serverless/my-artifact.zip'
```
