### PR TITLE
Add documentation about `noLimit` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ custom:
 ```
 
 This will fail if your package artifact exceeds 2mb. Supports whatever `bytes-iec` supports for the limit expression.
+
+If you want to ignore the limit for a specific deployment, you can pass the `--noLimit` option to the `serverless` command:
+
+```sh
+serverless deploy --stage staging --noLimit
+```


### PR DESCRIPTION
Adds example of using the `--noLimit` option and explains what it does.